### PR TITLE
Correct results of diff and sdiff

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,23 +1,19 @@
 {
-  "auth": "zef:raku-community-modules",
-  "build-depends": [
-  ],
-  "depends": [
-  ],
-  "description": "Compute `intelligent' differences between two files / lists",
-  "license": "NOASSERTION",
   "name": "Algorithm::Diff",
+  "description": "Compute `intelligent' differences between two files / lists",
+  "version": "0.0.3",
   "perl": "6.*",
+  "auth": "zef:raku-community-modules",
+  "depends": [],
+  "build-depends": [],
+  "test-depends": [],
   "provides": {
     "Algorithm::Diff": "lib/Algorithm/Diff.rakumod"
   },
-  "resources": [
-  ],
-  "source-url": "https://github.com/raku-community-modules/Algorithm-Diff.git",
+  "resources": [],
+  "license": "NOASSERTION",
   "tags": [
     "CPAN5"
   ],
-  "test-depends": [
-  ],
-  "version": "0.0.2"
+  "source-url": "https://github.com/raku-community-modules/Algorithm-Diff.git"
 }

--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
     "Algorithm::Diff": "lib/Algorithm/Diff.rakumod"
   },
   "resources": [],
-  "license": "NOASSERTION",
+  "license": "Artistic-2.0",
   "tags": [
     "CPAN5"
   ],

--- a/lib/Algorithm/Diff.rakumod
+++ b/lib/Algorithm/Diff.rakumod
@@ -383,8 +383,8 @@ sub diff( @a, @b ) is export {
     traverse_sequences(
       @a, @b,
       MATCH     => sub ($x,$y) { @retval.append( @hunk ); @hunk = ()   },
-      DISCARD_A => sub ($x,$y) { @hunk.append( [ '-', $x, @a[ $x ] ] ) },
-      DISCARD_B => sub ($x,$y) { @hunk.append( [ '+', $y, @b[ $y ] ] ) }
+      DISCARD_A => sub ($x,$y) { @hunk.push( [ '-', $x, @a[ $x ] ] ) },
+      DISCARD_B => sub ($x,$y) { @hunk.push( [ '+', $y, @b[ $y ] ] ) }
     );
     @retval, @hunk
 }
@@ -393,10 +393,10 @@ sub sdiff( @a, @b ) is export {
     my @retval;
     traverse_balanced(
       @a, @b,
-      MATCH     => sub ($x,$y) { @retval.append( [ 'u', @a[ $x ], @b[ $y ] ] ) },
-      DISCARD_A => sub ($x,$y) { @retval.append( [ '-', @a[ $x ],    ''    ] ) },
-      DISCARD_B => sub ($x,$y) { @retval.append( [ '+',    ''   , @b[ $y ] ] ) },
-      CHANGE    => sub ($x,$y) { @retval.append( [ 'c', @a[ $x ], @b[ $y ] ] ) }
+      MATCH     => sub ($x,$y) { @retval.push( [ 'u', @a[ $x ], @b[ $y ] ] ) },
+      DISCARD_A => sub ($x,$y) { @retval.push( [ '-', @a[ $x ],    ''    ] ) },
+      DISCARD_B => sub ($x,$y) { @retval.push( [ '+',    ''   , @b[ $y ] ] ) },
+      CHANGE    => sub ($x,$y) { @retval.push( [ 'c', @a[ $x ], @b[ $y ] ] ) }
     );
     @retval
 }


### PR DESCRIPTION
The original implementation does _not_ produce results that much the outputs in the documentation. This PR fixes that.

-----

###  Old version, 0.0.2

```perl6
my @a = <a b c e h j l m n p>;
my @b = <b c d e f j k l m r s t>;

my $diff = diff( @a, @b );

say $diff.raku;
```

gives :

```
$(["-", 0, "a", "+", 2, "d", "-", 4, "h", "+", 4, "f", "+", 6, "k"], ["-", 8, "n", "+", 9, "r", "-", 9, "p", "+", 10, "s", "+", 11, "t"])
```

-----

###  PR's version, 0.0.3

```perl6
my @a = <a b c e h j l m n p>;
my @b = <b c d e f j k l m r s t>;

my $diff = diff( @a, @b );

say $diff.raku;
```

gives :

```
$([["-", 0, "a"], ["+", 2, "d"], ["-", 4, "h"], ["+", 4, "f"], ["+", 6, "k"]], [["-", 8, "n"], ["+", 9, "r"], ["-", 9, "p"], ["+", 10, "s"], ["+", 11, "t"]])
```

With PR's version we get this result (in a Jupyter notebook):

![Screenshot 2024-05-02 at 12 54 19 PM](https://github.com/raku-community-modules/Algorithm-Diff/assets/4943081/92619258-b4a6-4bb7-b539-3f5d630997ee)
